### PR TITLE
Don't register handler with Avalonia if it is already registered.

### DIFF
--- a/EventBinder.Shared/EventBinding.cs
+++ b/EventBinder.Shared/EventBinding.cs
@@ -115,8 +115,11 @@ namespace EventBinder
             {
 	            lock (sync)
 	            {
-                    eventInfo.AddEventHandler(frameworkElement, handler);
-			        binded = true;
+                    if (!binded)
+                    {
+                        eventInfo.AddEventHandler(frameworkElement, handler);
+                        binded = true;
+                    }
                 }
             };
 #else


### PR DESCRIPTION
Non-Avalonia builds already have a similar guard.

I'm pretty sure this the same issue mentioned in #66 as I was observing that my Click event handlers were being called twice until I made this fix